### PR TITLE
Treasury pallet

### DIFF
--- a/pallets/treasury/src/benchmarking.rs
+++ b/pallets/treasury/src/benchmarking.rs
@@ -6,30 +6,108 @@ use super::*;
 use crate::Pallet as Treasury;
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
+use frame_support::traits::fungible::Mutate;
+use frame_support::traits::fungible::Inspect;
+use frame_support::traits::fungibles::Inspect as FungiblesInspect;
+use frame_support::traits::fungibles::Mutate as FungiblesMutate;
+use frame_support::traits::fungibles::Create;
+
+/// Benchmark Helper
+pub trait BenchmarkHelper<AssetId> {
+    fn convert_to_asset_id(id: u32) -> AssetId;
+}
+
+impl<AssetId> BenchmarkHelper<AssetId> for ()
+where
+    AssetId: From<u32>,
+{
+    fn convert_to_asset_id(id: u32) -> AssetId {
+        id.into()
+    }
+}
 
 #[benchmarks]
 mod benchmarks {
 	use super::*;
 
-	#[benchmark]
-	fn do_something() {
-		let value = 100u32.into();
-		let caller: T::AccountId = whitelisted_caller();
-		#[extrinsic_call]
-		do_something(RawOrigin::Signed(caller), value);
+	// #[benchmark]
+	// fn do_something() {
+	// 	let value = 100u32.into();
+	// 	let caller: T::AccountId = whitelisted_caller();
+	// 	#[extrinsic_call]
+	// 	do_something(RawOrigin::Signed(caller), value);
 
-		assert_eq!(Something::<T>::get(), Some(value));
+	// 	assert_eq!(Something::<T>::get(), Some(value));
+	// }
+
+	// #[benchmark]
+	// fn cause_error() {
+	// 	Something::<T>::put(100u32);
+	// 	let caller: T::AccountId = whitelisted_caller();
+	// 	#[extrinsic_call]
+	// 	cause_error(RawOrigin::Signed(caller));
+
+	// 	assert_eq!(Something::<T>::get(), Some(101u32));
+	// }
+
+	#[benchmark]
+	fn fund_treasury_asset() {
+		let caller: T::AccountId = whitelisted_caller();
+		let value = 1_000_000_u32.into();
+		let asset_id = T::BenchmarkHelper::convert_to_asset_id(1);
+
+		T::Fungibles::create(
+			asset_id.clone(),
+			caller.clone(),
+			true,
+			1_u32.into()
+		);	
+
+		T::Fungibles::set_balance(asset_id.clone(), &caller, value);
+		// let caller_balance = T::NativeBalance::get().free_balance(&caller);
+		let treasury_balance = T::Fungibles::balance(asset_id.clone(), &Pallet::<T>::treasury_account_id());
+
+		#[extrinsic_call]
+		Treasury::fund_treasury_asset(
+			RawOrigin::Signed(caller.clone()),
+			100_000_u32.into(),
+			asset_id.clone()
+		);
+
+		assert_eq!(
+			T::Fungibles::balance(asset_id.clone(), &caller),
+			900_000_u32.into()
+		);
+		assert_eq!(
+			T::Fungibles::balance(asset_id, &Pallet::<T>::treasury_account_id()),
+			100_000_u32.into()
+		);
 	}
 
 	#[benchmark]
-	fn cause_error() {
-		Something::<T>::put(100u32);
+	fn fund_treasury_native() {
 		let caller: T::AccountId = whitelisted_caller();
-		#[extrinsic_call]
-		cause_error(RawOrigin::Signed(caller));
+		let value = 1_000_000_u32.into();
+		T::NativeBalance::set_balance(&caller, value);
+		// let caller_balance = T::NativeBalance::get().free_balance(&caller);
+		let treasury_balance = T::NativeBalance::balance(&Pallet::<T>::treasury_account_id());
 
-		assert_eq!(Something::<T>::get(), Some(101u32));
+		#[extrinsic_call]
+		Treasury::fund_treasury_native(
+			RawOrigin::Signed(caller.clone()),
+			100_000_u32.into()
+		);
+
+		assert_eq!(
+			T::NativeBalance::balance(&caller),
+			900_000_u32.into()
+		);
+		assert_eq!(
+			T::NativeBalance::balance(&Pallet::<T>::treasury_account_id()),
+			100_000_u32.into()
+		);
 	}
+
 
 	impl_benchmark_test_suite!(Treasury, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -11,11 +11,14 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
+#[cfg(feature = "runtime-benchmarks")]
+pub use benchmarking::BenchmarkHelper;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	pallet_prelude::{ConstU32, TypeInfo},
 	BoundedVec,
 };
+use sp_std::vec::Vec;
 
 #[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug, Clone, PartialEq)]
 pub enum NumOfPeriodicPayouts {
@@ -148,6 +151,10 @@ pub mod pallet {
 		type MediumSpenderThreshold: Get<BalanceOf<Self>>;
 		#[pallet::constant]
 		type AmountHeldOnProposal: Get<BalanceOf<Self>>;
+
+		/// The benchmarks need a way to create asset ids from u32s.
+		#[cfg(feature = "runtime-benchmarks")]
+		type BenchmarkHelper: BenchmarkHelper<AssetIdOf<Self>>;
 	}
 
 	#[pallet::pallet]

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -171,7 +171,7 @@ pub mod pallet {
 		amount: BalanceOf<T>,
 	}
 
-	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen)]
+	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug)]
 	#[scale_info(skip_type_params(T))]
 	pub struct SpendingProposal<T: Config> {
 		title: BoundedVec<u8, ConstU32<32>>,

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -16,11 +16,22 @@ mod benchmarking;
 // https://paritytech.github.io/polkadot-sdk/master/frame_support/attr.pallet.html#dev-mode-palletdev_mode
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {
+	use crate::AssetPriceLookup;
+	use frame_support::sp_runtime::traits::AccountIdConversion;
+	use frame_support::traits::tokens::Preservation;
+	use frame_support::PalletId;
 	use frame_support::{
 		pallet_prelude::*,
-		traits::{fungible, fungibles},
+		traits::{
+			fungible::{self, Mutate as FungibleMutate},
+			fungibles::{self, Mutate as FungiblesMutate},
+			EnsureOrigin,
+		},
+		Twox64Concat,
 	};
-	use frame_system::pallet_prelude::*;
+	use frame_system::pallet_prelude::{OriginFor, *};
+
+	const PALLET_ID: PalletId = PalletId(*b"treasury");
 
 	pub type AssetIdOf<T> = <<T as Config>::Fungibles as fungibles::Inspect<
 		<T as frame_system::Config>::AccountId,
@@ -36,6 +47,14 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
+
+	#[pallet::origin]
+	#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
+	pub enum Origin {
+		SmallSpender,
+		MediumSpender,
+		BigSpender,
+	}
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
@@ -53,7 +72,7 @@ pub mod pallet {
 			+ fungible::freeze::Mutate<Self::AccountId>;
 
 		/// Type to access the Assets Pallet.
-		type Fungibles: fungibles::Inspect<Self::AccountId>
+		type Fungibles: fungibles::Inspect<Self::AccountId, Balance = BalanceOf<Self>>
 			+ fungibles::Mutate<Self::AccountId>
 			+ fungibles::Create<Self::AccountId>;
 
@@ -67,22 +86,56 @@ pub mod pallet {
 		// A custom, configurable origin that you can use. It can be wired to be `EnsureSigned`,
 		// `EnsureRoot`, or any custom implementation at the runtime level.
 		// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_origin/index.html#asserting-on-a-custom-external-origin
-		type CustomOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+		type TreasuryOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		// Here is an associated type to give you access to your simple asset price lookup function
 		type AssetPriceLookup: crate::AssetPriceLookup<Self>;
 
-		// Small Spender
-		type SmallSpender: EnsureOrigin<Self::RuntimeOrigin>;
+		// type SmallSpender: EnsureOrigin<Self::RuntimeOrigin>;
+		// type BigSpender: EnsureOrigin<Self::RuntimeOrigin>;
+
+		#[pallet::constant]
+		type SmallSpenderThreshold: Get<BalanceOf<Self>>;
+		#[pallet::constant]
+		type MediumSpenderThreshold: Get<BalanceOf<Self>>;
 	}
 
 	/// The pallet's storage items.
 	/// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#storage
 	/// https://paritytech.github.io/polkadot-sdk/master/frame_support/pallet_macros/attr.storage.html
+
+	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen)]
+	#[scale_info(skip_type_params(T))]
+	pub struct SpendingProposal<T: Config> {
+		title: [u8; 32],
+		description: [u8; 500],
+		proposer: T::AccountId,
+		beneficiary: T::AccountId,
+		#[codec(compact)]
+		amount: BalanceOf<T>,
+		spender_type: Origin,
+		approved: bool,
+	}
+
 	#[pallet::storage]
-	pub type Something<T> = StorageValue<Value = u32>;
+	pub type SpendingProposals<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, T::AccountId, Twox64Concat, u16, SpendingProposal<T>>;
+
 	#[pallet::storage]
-	pub type SomethingMap<T: Config> = StorageMap<Key = T::AccountId, Value = BlockNumberFor<T>>;
+	pub type NumOfProposalsFromProposer<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, u16, ValueQuery, GetDefault>;
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig;
+
+	#[pallet::genesis_build]
+	impl BuildGenesisConfig for GenesisConfig {
+		fn build(&self) {
+			const PALLET_ID: PalletId = PalletId(*b"treasury");
+			PALLET_ID.try_into_account().expect("Failed to create account ID")
+		}
+	}
 
 	/// Errors inform users that something went wrong.
 	/// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#event-and-error
@@ -91,6 +144,13 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// We usually use passive tense for events.
 		SomethingStored { something: u32, who: T::AccountId },
+		// index_count is the number of proposals the proposer has made, starting from 0
+		AddedProposal {
+			proposer: T::AccountId,
+			index_count: u16,
+			amount: BalanceOf<T>,
+			title: [u8; 32],
+		},
 	}
 
 	/// Errors inform users that something went wrong.
@@ -122,6 +182,56 @@ pub mod pallet {
 	/// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#dispatchables
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		pub fn fund_treasury_asset(
+			origin: OriginFor<T>,
+			amount: BalanceOf<T>,
+			asset_id: AssetIdOf<T>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			T::Fungibles::transfer(
+				asset_id,
+				&who,
+				&Self::treasury_account_id(),
+				amount,
+				Preservation::Expendable,
+			)?;
+			Ok(())
+		}
+
+		pub fn fund_treasury_native(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			T::NativeBalance::transfer(
+				&who,
+				&Self::treasury_account_id(),
+				amount,
+				Preservation::Expendable,
+			)?;
+			Ok(())
+		}
+
+		pub fn approve_proposal(
+			origin: OriginFor<T>,
+			proposer: T::AccountId,
+			index: u16,
+		) -> DispatchResult {
+			let _who = T::TreasuryOrigin::ensure_origin(origin)?;
+		
+			SpendingProposals::<T>::try_mutate(&proposer, index, |proposal| {
+				match proposal {
+					Some(p) => {
+						if p.approved {
+							return Err("Proposal already approved");
+						}
+						p.approved = true;
+						Ok(())
+					},
+					None => Err("Proposal does not exist"),
+				}
+			})?;
+		
+			Ok(())
+		}
+
 		/// An example dispatchable that takes a singles value as a parameter, writes the value to
 		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
 		pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
@@ -131,7 +241,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			// Update storage.
-			<Something<T>>::put(something);
+			// <Something<T>>::put(something);
 
 			// Emit an event.
 			Self::deposit_event(Event::SomethingStored { something, who });
@@ -139,31 +249,36 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// An example dispatchable that may throw a custom error.
-		pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
-			let _who = ensure_signed(origin)?;
+		// /// An example dispatchable that may throw a custom error.
+		// pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
+		// 	let _who = ensure_signed(origin)?;
 
-			// Read a value from storage.
-			match <Something<T>>::get() {
-				// Return an error if the value has not been set.
-				None => Err(Error::<T>::NoneValue.into()),
-				Some(old) => {
-					// Increment the value read from storage; will error in the event of overflow.
-					let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
-					// Update the value in storage with the incremented result.
-					<Something<T>>::put(new);
-					Ok(())
-				},
-			}
-		}
+		// 	Ok(())
+		// 	// Read a value from storage.
+		// 	match <Something<T>>::get() {
+		// 		// Return an error if the value has not been set.
+		// 		None => Err(Error::<T>::NoneValue.into()),
+		// 		Some(old) => {
+		// 			// Increment the value read from storage; will error in the event of overflow.
+		// 			let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
+		// 			// Update the value in storage with the incremented result.
+		// 			<Something<T>>::put(new);
+		// 			Ok(())
+		// 		},
+		// 	}
+		// }
 
 		pub fn propose_spend(
 			origin: OriginFor<T>,
-			who: T::AccountId,
+			title: [u8; 32],
+			description: [u8; 500],
+			asset_id: AssetIdOf<T>,
 			amount: BalanceOf<T>,
+			proposer: T::AccountId,
+			beneficiary: T::AccountId,
 		) -> DispatchResult {
-			T::SmallSpender::ensure_origin(origin)?;
-			Self::do_propose_spend(who, amount)
+			let _anyone = ensure_signed(origin)?;
+			Self::do_propose_spend(title, description, asset_id, amount, proposer, beneficiary)
 		}
 
 		// Let's imagine you wanted to build a transfer extrinsic inside your pallet...
@@ -193,15 +308,75 @@ pub mod pallet {
 	//
 	// Compare this to the block above which has `#[pallet::call]` which makes them extrinsics!
 	impl<T: Config> Pallet<T> {
-		fn do_propose_spend(_who: T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
+		pub fn treasury_account_id() -> T::AccountId {
+			PALLET_ID.try_into_account().expect("Failed to create account ID")
+		}
+
+		pub fn send_native_funds_to_beneficiary(
+			beneficiary: T::AccountId,
+			amount: BalanceOf<T>,
+		) -> DispatchResult {
+			T::NativeBalance::transfer(
+				&Self::treasury_account_id(),
+				&beneficiary,
+				amount,
+				Preservation::Expendable,
+			)?;
+			Ok(())
+		}
+
+		pub fn send_asset_funds_to_beneficiary(
+			beneficiary: T::AccountId,
+			amount: BalanceOf<T>,
+			asset_id: AssetIdOf<T>,
+		) -> DispatchResult {
+			T::Fungibles::transfer(
+				asset_id,
+				&Self::treasury_account_id(),
+				&beneficiary,
+				amount,
+				Preservation::Expendable,
+			)?;
+			Ok(())
+		}
+
+		fn do_propose_spend(
+			title: [u8; 32],
+			description: [u8; 500],
+			asset_id: AssetIdOf<T>,
+			amount: BalanceOf<T>,
+			proposer: T::AccountId,
+			beneficiary: T::AccountId,
+		) -> DispatchResult {
 			// Write the logic for your extrinsic here, since this is "outside" of the macros.
 			// Following this kind of best practice can even allow you to move most of your
 			// pallet logic into different files, with better, more clear structure, rather
 			// than having a single huge complicated file.
-			if amount > 100_000u32.into() {
-				return Err("you are spending too much  money!".into());
-			}
 
+			let price_in_usd = T::AssetPriceLookup::usd_price(asset_id, amount);
+
+			// Determine the spender type based on the amount
+			let spender_type = if price_in_usd <= T::SmallSpenderThreshold::get() {
+				Origin::SmallSpender
+			} else if amount <= T::MediumSpenderThreshold::get() {
+				Origin::MediumSpender
+			} else {
+				Origin::BigSpender
+			};
+
+			let index_count = NumOfProposalsFromProposer::<T>::get(&proposer);
+
+			let proposal = SpendingProposal {
+				title,
+				description,
+				proposer: proposer.clone(),
+				beneficiary,
+				amount,
+				spender_type,
+				approved: false,
+			};
+
+			SpendingProposals::<T>::insert(&proposer, index_count, proposal);
 			Ok(())
 		}
 	}
@@ -217,4 +392,6 @@ pub trait AssetPriceLookup<T: Config> {
 		asset_a_amount: AssetBalanceOf<T>,
 		asset_b_id: AssetIdOf<T>,
 	) -> AssetBalanceOf<T>;
+
+	fn usd_price(asset_id: AssetIdOf<T>, amount: AssetBalanceOf<T>) -> AssetBalanceOf<T>;
 }

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -18,7 +18,7 @@ mod benchmarking;
 pub mod pallet {
 	use crate::AssetPriceLookup;
 	use frame_support::sp_runtime::traits::AccountIdConversion;
-	use frame_support::traits::tokens::Preservation;
+	use frame_support::traits::tokens::{Precision, Preservation};
 	use frame_support::PalletId;
 	use frame_support::{
 		pallet_prelude::*,
@@ -34,6 +34,8 @@ pub mod pallet {
 	use frame_support::traits::fungible::MutateHold;
 
 	const PALLET_ID: PalletId = PalletId(*b"treasury");
+
+	
 
 	pub type AssetIdOf<T> = <<T as Config>::Fungibles as fungibles::Inspect<
 		<T as frame_system::Config>::AccountId,
@@ -117,6 +119,8 @@ pub mod pallet {
 		type SmallSpenderThreshold: Get<BalanceOf<Self>>;
 		#[pallet::constant]
 		type MediumSpenderThreshold: Get<BalanceOf<Self>>;
+		#[pallet::constant]
+		type AmountHeldOnProposal: Get<BalanceOf<Self>>;
 	}
 
 	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug, Clone, PartialEq)]
@@ -332,6 +336,7 @@ pub mod pallet {
 				None => return Err("Proposal does not exist"),
 			})?;
 
+			T::NativeBalance::release(&HoldReason::SpendingProposal.into(), &proposer, T::AmountHeldOnProposal::get(), Precision::BestEffort)?;
 			Ok(())
 		}
 

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -174,9 +174,7 @@ pub mod pallet {
 
 	#[pallet::genesis_build]
 	impl BuildGenesisConfig for GenesisConfig {
-		fn build(&self) {
-			PALLET_ID.try_into_account().expect("Failed to create account ID")
-		}
+		fn build(&self) { }
 	}
 
 	/// Errors inform users that something went wrong.
@@ -345,7 +343,7 @@ pub mod pallet {
 	// Compare this to the block above which has `#[pallet::call]` which makes them extrinsics!
 	impl<T: Config> Pallet<T> {
 		pub fn treasury_account_id() -> T::AccountId {
-			PALLET_ID.try_into_account().expect("Failed to create account ID")
+			PALLET_ID.into_account_truncating()
 		}
 
 		pub fn setup_payout_instances(proposal: &SpendingProposal<T>) -> DispatchResult {

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -141,8 +141,8 @@ pub mod pallet {
 	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen)]
 	#[scale_info(skip_type_params(T))]
 	pub struct SpendingProposal<T: Config> {
-		title: [u8; 32],
-		description: [u8; 500],
+		title: BoundedVec<u8, ConstU32<32>>,
+		description: BoundedVec<u8, ConstU32<500>>,
 		proposer: T::AccountId,
 		beneficiary: T::AccountId,
 		#[codec(compact)]
@@ -189,7 +189,7 @@ pub mod pallet {
 			proposer: T::AccountId,
 			index_count: u16,
 			amount: BalanceOf<T>,
-			title: [u8; 32],
+			title: BoundedVec<u8, ConstU32<32>>,
 		},
 	}
 
@@ -274,8 +274,8 @@ pub mod pallet {
 
 		pub fn propose_spend(
 			origin: OriginFor<T>,
-			title: [u8; 32],
-			description: [u8; 500],
+			title: BoundedVec<u8, ConstU32<32>>,
+			description: BoundedVec<u8, ConstU32<500>>,
 			asset_id: AssetIdOf<T>,
 			amount: BalanceOf<T>,
 			proposer: T::AccountId,
@@ -454,8 +454,8 @@ pub mod pallet {
 			Ok(())
 		}
 		fn do_propose_spend(
-			title: [u8; 32],
-			description: [u8; 500],
+			title: BoundedVec<u8, ConstU32<32>>,
+			description: BoundedVec<u8, ConstU32<500>>,
 			asset_id: AssetIdOf<T>,
 			amount: BalanceOf<T>,
 			proposer: T::AccountId,

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -465,7 +465,7 @@ pub mod pallet {
 					// Setup periodic payouts
 					let curr_block_number: BlockNumberFor<T> =
 						<frame_system::Pallet<T>>::block_number();
-					for i in 0..number_of_payout_instances {
+					for i in 1..=number_of_payout_instances {
 						let block_number: BlockNumberFor<T> =
 							curr_block_number + (i as u32 * payment_each_n_blocks).into();
 						let payout_instance: PeriodicPayoutInstance<T> = PeriodicPayoutInstance {

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -11,10 +11,11 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
-use codec::{Codec, Decode, Encode, HasCompact, MaxEncodedLen};
-use frame_support::pallet_prelude::ConstU32;
-use frame_support::pallet_prelude::TypeInfo;
-use frame_support::BoundedVec;
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{
+	pallet_prelude::{ConstU32, TypeInfo},
+	BoundedVec,
+};
 
 #[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug, Clone, PartialEq)]
 pub enum NumOfPeriodicPayouts {
@@ -74,18 +75,16 @@ pub struct SpendingProposal<T: Config> {
 pub mod pallet {
 	use super::*;
 	use crate::AssetPriceLookup;
-	use frame_support::sp_runtime::traits::AccountIdConversion;
-	use frame_support::traits::fungible::MutateHold;
-	use frame_support::traits::tokens::{Fortitude, Precision, Preservation};
-	use frame_support::PalletId;
 	use frame_support::{
 		pallet_prelude::*,
+		sp_runtime::traits::AccountIdConversion,
 		traits::{
-			fungible::{self, Mutate as FungibleMutate},
+			fungible::{self, Mutate as FungibleMutate, MutateHold},
 			fungibles::{self, Mutate as FungiblesMutate},
+			tokens::{Fortitude, Precision, Preservation},
 			EnsureOrigin,
 		},
-		Twox64Concat,
+		PalletId, Twox64Concat,
 	};
 	use frame_system::pallet_prelude::{OriginFor, *};
 	use sp_runtime::Percent;
@@ -471,7 +470,7 @@ pub mod pallet {
 						PayoutInstances::append(block_number, payout_instance);
 					}
 				},
-				PayoutType::Instant => {
+				PayoutType::Instant =>
 					if proposal.asset_id == T::NATIVE_ASSET_ID {
 						Self::send_native_funds_to_beneficiary(
 							&proposal.beneficiary,
@@ -483,8 +482,7 @@ pub mod pallet {
 							proposal.amount,
 							&proposal.asset_id,
 						)?;
-					}
-				},
+					},
 			}
 
 			Ok(())

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -117,7 +117,7 @@ pub mod pallet {
 		upfront: u8,
 		periodic: u8,
 		after_fully_complete: u8,
-		
+
 		num_of_periodic_payouts: NumOfPeriodicPayouts,
 		payment_each_n_blocks: u32,
 	}
@@ -174,7 +174,7 @@ pub mod pallet {
 
 	#[pallet::genesis_build]
 	impl BuildGenesisConfig for GenesisConfig {
-		fn build(&self) { }
+		fn build(&self) {}
 	}
 
 	/// Errors inform users that something went wrong.
@@ -350,12 +350,14 @@ pub mod pallet {
 			match &proposal.payout_type {
 				PayoutType::Periodic(payout) => {
 					let upfront_amount = Percent::from_percent(payout.upfront) * proposal.amount;
-					let after_fully_complete_amount = Percent::from_percent(payout.after_fully_complete) * proposal.amount;
+					let after_fully_complete_amount =
+						Percent::from_percent(payout.after_fully_complete) * proposal.amount;
 					let periodic_amount = Percent::from_percent(payout.periodic) * proposal.amount;
 
 					let number_of_payout_instances = payout.num_of_periodic_payouts.clone() as u8;
 					let payment_each_n_blocks = payout.payment_each_n_blocks;
-					let payout_instance_amount: BalanceOf<T> = Percent::from_percent(100 /  number_of_payout_instances) * periodic_amount;
+					let payout_instance_amount: BalanceOf<T> =
+						Percent::from_percent(100 / number_of_payout_instances) * periodic_amount;
 
 					// Send upfront amount to beneficiary
 					if proposal.asset_id == T::NATIVE_ASSET_ID {
@@ -372,9 +374,11 @@ pub mod pallet {
 					}
 
 					// Setup periodic payouts
-					let curr_block_number: BlockNumberFor<T> = <frame_system::Pallet<T>>::block_number();
+					let curr_block_number: BlockNumberFor<T> =
+						<frame_system::Pallet<T>>::block_number();
 					for i in 0..number_of_payout_instances {
-						let block_number: BlockNumberFor<T> = curr_block_number + (i as u32 * payment_each_n_blocks).into();
+						let block_number: BlockNumberFor<T> =
+							curr_block_number + (i as u32 * payment_each_n_blocks).into();
 						let payout_instance: PeriodicPayoutInstance<T> = PeriodicPayoutInstance {
 							proposer: proposal.proposer.clone(),
 							// proposal_index: proposal.,
@@ -441,7 +445,8 @@ pub mod pallet {
 						"Payout percentages must sum to 100"
 					);
 					ensure!(
-						payout.payment_each_n_blocks > 0, "Payment each n blocks must be greater than 0"
+						payout.payment_each_n_blocks > 0,
+						"Payment each n blocks must be greater than 0"
 					);
 				},
 				PayoutType::Instant => {},

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -55,7 +55,7 @@ pub mod pallet {
 			let payout_instances = PayoutInstances::<T>::get(_n);
 			for payout in payout_instances {
 				Self::exec_payout_instance(payout);
-			};
+			}
 			Weight::zero()
 		}
 	}
@@ -125,12 +125,12 @@ pub mod pallet {
 	// full amount = upfront + periodic + after_fully_complete
 	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug, Clone, PartialEq)]
 	pub struct PeriodicPayoutPercentage {
-		upfront: u8,
-		periodic: u8,
-		after_fully_complete: u8,
+		pub upfront: u8,
+		pub periodic: u8,
+		pub after_fully_complete: u8,
 
-		num_of_periodic_payouts: NumOfPeriodicPayouts,
-		payment_each_n_blocks: u32,
+		pub num_of_periodic_payouts: NumOfPeriodicPayouts,
+		pub payment_each_n_blocks: u32,
 	}
 
 	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug, Clone, PartialEq)]
@@ -363,7 +363,7 @@ pub mod pallet {
 					let upfront_amount = Percent::from_percent(payout.upfront) * proposal.amount;
 					// TODO: Implement after_fully_complete
 					// let after_fully_complete_amount =
-						// Percent::from_percent(payout.after_fully_complete) * proposal.amount;
+					// Percent::from_percent(payout.after_fully_complete) * proposal.amount;
 					let periodic_amount = Percent::from_percent(payout.periodic) * proposal.amount;
 
 					let number_of_payout_instances = payout.num_of_periodic_payouts.clone() as u8;
@@ -480,7 +480,6 @@ pub mod pallet {
 				)?;
 			}
 			Ok(())
-
 		}
 
 		fn do_propose_spend(

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -250,7 +250,7 @@ pub mod pallet {
 						return Err("Proposal already approved");
 					}
 					p.approved = true;
-					Self::setup_payout_instances(p);
+					Self::setup_payout_instances(p)?;
 					return Ok(());
 				},
 				None => return Err("Proposal does not exist"),

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -385,6 +385,7 @@ pub mod pallet {
 			};
 
 			SpendingProposals::<T>::insert(&proposer, index_count, proposal);
+			NumOfProposalsFromProposer::<T>::insert(&proposer, index_count + 1);
 			Ok(())
 		}
 	}

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -117,17 +117,14 @@ pub mod pallet {
 		// or, do something like this:
 		// type Fungibles: fungibles::Inspect<Self::AccountId, Balance = BalanceOf<Self>>
 
-		// A custom, configurable origin that you can use. It can be wired to be `EnsureSigned`,
-		// `EnsureRoot`, or any custom implementation at the runtime level.
+		// Governance origin to ensure the origin of a call is authorized
 		// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_origin/index.html#asserting-on-a-custom-external-origin
 		type GovernanceOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		// Here is an associated type to give you access to your simple asset price lookup function
 		type AssetPriceLookup: crate::AssetPriceLookup<Self>;
 
-		// type SmallSpender: EnsureOrigin<Self::RuntimeOrigin>;
-		// type BigSpender: EnsureOrigin<Self::RuntimeOrigin>;
-
+		// Thresholds for different spender categories
 		#[pallet::constant]
 		type SmallSpenderThreshold: Get<BalanceOf<Self>>;
 		#[pallet::constant]
@@ -282,42 +279,6 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// An example dispatchable that takes a singles value as a parameter, writes the value to
-		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
-		// pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
-		// 	// Check that the extrinsic was signed and get the signer.
-		// 	// This function will return an error if the extrinsic is not signed.
-		// 	// // https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_origin/index.html
-		// 	let who = ensure_signed(origin)?;
-
-		// 	// Update storage.
-		// 	// <Something<T>>::put(something);
-
-		// 	// Emit an event.
-		// 	Self::deposit_event(Event::SomethingStored { something, who });
-
-		// 	Ok(())
-		// }
-
-		// /// An example dispatchable that may throw a custom error.
-		// pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
-		// 	let _who = ensure_signed(origin)?;
-
-		// 	Ok(())
-		// 	// Read a value from storage.
-		// 	match <Something<T>>::get() {
-		// 		// Return an error if the value has not been set.
-		// 		None => Err(Error::<T>::NoneValue.into()),
-		// 		Some(old) => {
-		// 			// Increment the value read from storage; will error in the event of overflow.
-		// 			let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
-		// 			// Update the value in storage with the incremented result.
-		// 			<Something<T>>::put(new);
-		// 			Ok(())
-		// 		},
-		// 	}
-		// }
-
 		pub fn propose_spend(
 			origin: OriginFor<T>,
 			title: BoundedVec<u8, ConstU32<32>>,
@@ -426,23 +387,24 @@ pub mod pallet {
 							if p.asset_id == T::NATIVE_ASSET_ID {
 								Self::send_native_funds_to_beneficiary(
 									&p.beneficiary,
-									Percent::from_percent(periodic_payout_percentage.after_fully_complete)
-										* p.amount,
+									Percent::from_percent(
+										periodic_payout_percentage.after_fully_complete,
+									) * p.amount,
 								)?;
 							} else {
 								Self::send_asset_funds_to_beneficiary(
 									&p.beneficiary,
-									Percent::from_percent(periodic_payout_percentage.after_fully_complete)
-										* p.amount,
+									Percent::from_percent(
+										periodic_payout_percentage.after_fully_complete,
+									) * p.amount,
 									&p.asset_id,
 								)?;
 							}
 						}
-
 					}
 
-					return Ok(());	
-				}
+					return Ok(());
+				},
 				None => return Err("Proposal does not exist"),
 			})?;
 			Ok(())

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -134,6 +134,14 @@ pub mod pallet {
 		BigSpender,
 	}
 
+	/// A reason for placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason {
+		/// Funds held for stake proposing spend.
+		#[codec(index = 0)]
+		SpendingProposal,
+	}
+
 	#[derive(TypeInfo, Encode, Decode, MaxEncodedLen, Debug, Clone, PartialEq)]
 	pub enum NumOfPeriodicPayouts {
 		Five = 5,
@@ -207,14 +215,6 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl BuildGenesisConfig for GenesisConfig {
 		fn build(&self) {}
-	}
-
-	/// A reason for placing a hold on funds.
-	#[pallet::composite_enum]
-	pub enum HoldReason {
-		/// Funds held for stake proposing spend.
-		#[codec(index = 0)]
-		SpendingProposal,
 	}
 
 	/// Dispatchable functions allows users to interact with the pallet and invoke state changes.

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -208,10 +208,7 @@ pub mod pallet {
 	/// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#event-and-error
 	#[pallet::error]
 	pub enum Error<T> {
-		/// Error names should be descriptive.
-		NoneValue,
-		/// Errors should have helpful documentation associated with them.
-		StorageOverflow,
+		PayoutPercentagesMustSumTo100,
 	}
 
 	/// Dispatchable functions allows users to interact with the pallet and invoke state changes.
@@ -454,7 +451,7 @@ pub mod pallet {
 				PayoutType::Periodic(payout) => {
 					ensure!(
 						payout.upfront + payout.after_fully_complete + payout.periodic == 100,
-						"Payout percentages must sum to 100"
+						Error::<T>::PayoutPercentagesMustSumTo100
 					);
 					ensure!(
 						payout.payment_each_n_blocks > 0,
@@ -491,11 +488,6 @@ pub mod pallet {
 			beneficiary: T::AccountId,
 			payout_type: PayoutType,
 		) -> DispatchResult {
-			// Write the logic for your extrinsic here, since this is "outside" of the macros.
-			// Following this kind of best practice can even allow you to move most of your
-			// pallet logic into different files, with better, more clear structure, rather
-			// than having a single huge complicated file.
-
 			Self::check_payout_type(&payout_type)?;
 
 			let price_in_usd = T::AssetPriceLookup::usd_price(&asset_id, amount);

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -150,7 +150,7 @@ pub mod pallet {
 		asset_id: AssetIdOf<T>,
 		spender_type: Origin,
 		payout_type: PayoutType,
-		approved: bool,
+		pub approved: bool,
 	}
 
 	/// The pallet's storage items.

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -218,24 +218,26 @@ pub mod pallet {
 			index: u16,
 		) -> DispatchResult {
 			let _who = T::TreasuryOrigin::ensure_origin(origin)?;
-			SpendingProposals::<T>::try_mutate(&proposer, index, |proposal| {
-				match proposal {
-					Some(p) => {
-						if p.approved {
-							return Err("Proposal already approved");
-						}
-						p.approved = true;
-						if p.asset_id == T::NATIVE_ASSET_ID {
-							Self::send_native_funds_to_beneficiary(&p.beneficiary, p.amount)?;
-						} else {
-							Self::send_asset_funds_to_beneficiary(&p.beneficiary, p.amount, p.asset_id.clone())?;
-						}
-						Ok(())
-					},
-					None => Err("Proposal does not exist"),
-				}
+			SpendingProposals::<T>::try_mutate(&proposer, index, |proposal| match proposal {
+				Some(p) => {
+					if p.approved {
+						return Err("Proposal already approved");
+					}
+					p.approved = true;
+					if p.asset_id == T::NATIVE_ASSET_ID {
+						Self::send_native_funds_to_beneficiary(&p.beneficiary, p.amount)?;
+					} else {
+						Self::send_asset_funds_to_beneficiary(
+							&p.beneficiary,
+							p.amount,
+							p.asset_id.clone(),
+						)?;
+					}
+					Ok(())
+				},
+				None => Err("Proposal does not exist"),
 			})?;
-		
+
 			Ok(())
 		}
 

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -226,9 +226,9 @@ pub mod pallet {
 						}
 						p.approved = true;
 						if p.asset_id == T::NATIVE_ASSET_ID {
-							Self::send_native_funds_to_beneficiary(p.beneficiary.clone(), p.amount)?;
+							Self::send_native_funds_to_beneficiary(&p.beneficiary, p.amount)?;
 						} else {
-							Self::send_asset_funds_to_beneficiary(p.beneficiary.clone(), p.amount, p.asset_id.clone())?;
+							Self::send_asset_funds_to_beneficiary(&p.beneficiary, p.amount, p.asset_id.clone())?;
 						}
 						Ok(())
 					},
@@ -320,7 +320,7 @@ pub mod pallet {
 		}
 
 		pub fn send_native_funds_to_beneficiary(
-			beneficiary: T::AccountId,
+			beneficiary: &T::AccountId,
 			amount: BalanceOf<T>,
 		) -> DispatchResult {
 			T::NativeBalance::transfer(
@@ -333,7 +333,7 @@ pub mod pallet {
 		}
 
 		pub fn send_asset_funds_to_beneficiary(
-			beneficiary: T::AccountId,
+			beneficiary: &T::AccountId,
 			amount: BalanceOf<T>,
 			asset_id: AssetIdOf<T>,
 		) -> DispatchResult {

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -236,27 +236,6 @@ pub mod pallet {
 			Ok(())
 		}
 
-		pub fn approve_proposal(
-			origin: OriginFor<T>,
-			proposer: T::AccountId,
-			index: u16,
-		) -> DispatchResult {
-			let _who = T::GovernanceOrigin::ensure_origin(origin)?;
-			SpendingProposals::<T>::try_mutate(&proposer, index, |proposal| match proposal {
-				Some(p) => {
-					if p.approved {
-						return Err("Proposal already approved");
-					}
-					p.approved = true;
-					Self::setup_payout_instances(p)?;
-					return Ok(());
-				},
-				None => return Err("Proposal does not exist"),
-			})?;
-
-			Ok(())
-		}
-
 		/// An example dispatchable that takes a singles value as a parameter, writes the value to
 		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
 		pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
@@ -313,6 +292,27 @@ pub mod pallet {
 				beneficiary,
 				payout_type,
 			)
+		}
+
+		pub fn approve_proposal(
+			origin: OriginFor<T>,
+			proposer: T::AccountId,
+			index: u16,
+		) -> DispatchResult {
+			let _who = T::GovernanceOrigin::ensure_origin(origin)?;
+			SpendingProposals::<T>::try_mutate(&proposer, index, |proposal| match proposal {
+				Some(p) => {
+					if p.approved {
+						return Err("Proposal already approved");
+					}
+					p.approved = true;
+					Self::setup_payout_instances(p)?;
+					return Ok(());
+				},
+				None => return Err("Proposal does not exist"),
+			})?;
+
+			Ok(())
 		}
 
 		// Let's imagine you wanted to build a transfer extrinsic inside your pallet...

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -6,7 +6,7 @@ use frame_support::{
 };
 use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
 use sp_core::H256;
-use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, IdentityLookup};
+use sp_runtime::{traits::{AccountIdConversion, BlakeTwo256, IdentityLookup}, BuildStorage};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type Balance = u128;
@@ -132,11 +132,12 @@ impl pallet_treasury::Config for Test {
 	type MediumSpenderThreshold = MediumSpenderThreshold;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type AmountHeldOnProposal = AmountHeldOnProposal;
+	type BenchmarkHelper = ();
 }
 
-// pub fn new_test_ext() -> sp_io::TestExternalities {
-// 	// learn how to improve your test setup:
-// 	// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html
-// 	// frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
-// 	RuntimeGenesisConfig::default().build_storage().unwrap().into()
-// }
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	// learn how to improve your test setup:
+	// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html
+	// frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+	RuntimeGenesisConfig::default().build_storage().unwrap().into()
+}

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -8,10 +8,7 @@ use frame_support::{parameter_types, PalletId};
 use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
 use sp_core::H256;
 use sp_runtime::traits::AccountIdConversion;
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage,
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type Balance = u128;

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -1,4 +1,5 @@
 use crate as pallet_treasury;
+use frame_support::parameter_types;
 use frame_support::{
 	derive_impl,
 	traits::{AsEnsureOriginWithArg, ConstU128, ConstU16, ConstU32, ConstU64},
@@ -9,7 +10,6 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
 };
-use frame_support::parameter_types;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type Balance = u128;
@@ -105,7 +105,10 @@ impl crate::AssetPriceLookup<Test> for SimplePriceLookup {
 		amt_a
 	}
 
-	fn usd_price(asset_id: &crate::AssetIdOf<Test>, amount: crate::AssetBalanceOf<Test>) -> crate::AssetBalanceOf<Test> {
+	fn usd_price(
+		asset_id: &crate::AssetIdOf<Test>,
+		amount: crate::AssetBalanceOf<Test>,
+	) -> crate::AssetBalanceOf<Test> {
 		amount
 	}
 }

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -1,14 +1,12 @@
 use crate as pallet_treasury;
-use frame_support::ord_parameter_types;
 use frame_support::{
-	derive_impl,
+	derive_impl, ord_parameter_types, parameter_types,
 	traits::{AsEnsureOriginWithArg, ConstU128, ConstU16, ConstU32, ConstU64},
+	PalletId,
 };
-use frame_support::{parameter_types, PalletId};
 use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
 use sp_core::H256;
-use sp_runtime::traits::AccountIdConversion;
-use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, IdentityLookup};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type Balance = u128;

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -1,17 +1,17 @@
 use crate as pallet_treasury;
-use frame_support::{parameter_types, PalletId};
+use frame_support::ord_parameter_types;
 use frame_support::{
 	derive_impl,
 	traits::{AsEnsureOriginWithArg, ConstU128, ConstU16, ConstU32, ConstU64},
 };
+use frame_support::{parameter_types, PalletId};
 use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
 use sp_core::H256;
+use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
 };
-use frame_support::ord_parameter_types;
-use sp_runtime::traits::AccountIdConversion;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type Balance = u128;
@@ -119,7 +119,7 @@ parameter_types! {
 	pub static SmallSpenderThreshold: u32 = 5000;
 	pub static MediumSpenderThreshold: u32 = 20000;
 	pub static GovernancePalletId: PalletId = PalletId(*b"test/gov");
-}	
+}
 
 ord_parameter_types! {
 	pub const GovernanceOrigin: u64 = AccountIdConversion::<u64>::into_account_truncating(&GovernancePalletId::get());

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -1,15 +1,17 @@
 use crate as pallet_treasury;
-use frame_support::parameter_types;
+use frame_support::{parameter_types, PalletId};
 use frame_support::{
 	derive_impl,
 	traits::{AsEnsureOriginWithArg, ConstU128, ConstU16, ConstU32, ConstU64},
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
 use sp_core::H256;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
 };
+use frame_support::ord_parameter_types;
+use sp_runtime::traits::AccountIdConversion;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type Balance = u128;
@@ -116,13 +118,18 @@ impl crate::AssetPriceLookup<Test> for SimplePriceLookup {
 parameter_types! {
 	pub static SmallSpenderThreshold: u32 = 5000;
 	pub static MediumSpenderThreshold: u32 = 20000;
+	pub static GovernancePalletId: PalletId = PalletId(*b"test/gov");
+}	
+
+ord_parameter_types! {
+	pub const GovernanceOrigin: u64 = AccountIdConversion::<u64>::into_account_truncating(&GovernancePalletId::get());
 }
 
 impl pallet_treasury::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type NativeBalance = Balances;
 	type Fungibles = Assets;
-	type GovernanceOrigin = EnsureRoot<u64>;
+	type GovernanceOrigin = EnsureSignedBy<GovernanceOrigin, u64>;
 	type AssetPriceLookup = SimplePriceLookup;
 	const NATIVE_ASSET_ID: crate::AssetIdOf<Self> = 0;
 	type SmallSpenderThreshold = SmallSpenderThreshold;

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -68,7 +68,7 @@ impl pallet_balances::Config for Test {
 	type MaxLocks = ConstU32<10>;
 	type MaxReserves = ();
 	type ReserveIdentifier = [u8; 8];
-	type RuntimeHoldReason = ();
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type FreezeIdentifier = ();
 	type MaxFreezes = ConstU32<10>;
 }
@@ -134,6 +134,7 @@ impl pallet_treasury::Config for Test {
 	const NATIVE_ASSET_ID: crate::AssetIdOf<Self> = 0;
 	type SmallSpenderThreshold = SmallSpenderThreshold;
 	type MediumSpenderThreshold = MediumSpenderThreshold;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 // pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -9,9 +9,10 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
 };
+use frame_support::parameter_types;
 
 type Block = frame_system::mocking::MockBlock<Test>;
-type Balance = u128;
+pub type Balance = u128;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
@@ -103,19 +104,31 @@ impl crate::AssetPriceLookup<Test> for SimplePriceLookup {
 		// you can write more clever function here for more accurate testing
 		amt_a
 	}
+
+	fn usd_price(asset_id: &crate::AssetIdOf<Test>, amount: crate::AssetBalanceOf<Test>) -> crate::AssetBalanceOf<Test> {
+		amount
+	}
+}
+
+parameter_types! {
+	pub static SmallSpenderThreshold: u32 = 5000;
+	pub static MediumSpenderThreshold: u32 = 20000;
 }
 
 impl pallet_treasury::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type NativeBalance = Balances;
 	type Fungibles = Assets;
-	type CustomOrigin = EnsureRoot<u64>;
+	type GovernanceOrigin = EnsureRoot<u64>;
 	type AssetPriceLookup = SimplePriceLookup;
-	type SmallSpender = EnsureRoot<u64>;
+	const NATIVE_ASSET_ID: crate::AssetIdOf<Self> = 0;
+	type SmallSpenderThreshold = SmallSpenderThreshold;
+	type MediumSpenderThreshold = MediumSpenderThreshold;
 }
 
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	// learn how to improve your test setup:
-	// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html
-	frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
-}
+// pub fn new_test_ext() -> sp_io::TestExternalities {
+// 	// learn how to improve your test setup:
+// 	// https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html
+// 	// frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+// 	RuntimeGenesisConfig::default().build_storage().unwrap().into()
+// }

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -119,6 +119,7 @@ parameter_types! {
 	pub static SmallSpenderThreshold: u32 = 5000;
 	pub static MediumSpenderThreshold: u32 = 20000;
 	pub static GovernancePalletId: PalletId = PalletId(*b"test/gov");
+	pub const AmountHeldOnProposal: u128 = 100;
 }
 
 ord_parameter_types! {
@@ -135,6 +136,7 @@ impl pallet_treasury::Config for Test {
 	type SmallSpenderThreshold = SmallSpenderThreshold;
 	type MediumSpenderThreshold = MediumSpenderThreshold;
 	type RuntimeHoldReason = RuntimeHoldReason;
+	type AmountHeldOnProposal = AmountHeldOnProposal;
 }
 
 // pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::{mock::*, *};
+use frame_support::traits::fungible::Mutate;
 use frame_support::{assert_noop, assert_ok, traits::fungibles};
 use sp_io::TestExternalities as TestState;
 
@@ -12,7 +13,13 @@ pub(crate) struct StateBuilder {
 
 impl Default for StateBuilder {
 	fn default() -> Self {
-		Self { balances: vec![(ALICE, 100_000), (BOB, 100_000)] }
+		Self {
+			balances: vec![
+				(Treasury::treasury_account_id(), 999_999),
+				(ALICE, 100_000),
+				(BOB, 100_000),
+			],
+		}
 	}
 }
 
@@ -22,26 +29,33 @@ impl StateBuilder {
 
 		// Setup initial state
 		ext.execute_with(|| {
-
+			for (who, amount) in &self.balances {
+				<Test as Config>::NativeBalance::set_balance(who, *amount);
+			}
 		});
 
 		ext.execute_with(test);
 
 		// Assertions that must always hold
 		ext.execute_with(|| {
-			assert_eq!(
-				true,
-				true
-			);
+			assert_eq!(true, true);
 		})
 	}
 
-	fn add_balance(
+	fn add_user_balance(
 		mut self,
 		who: <Test as frame_system::Config>::AccountId,
 		amount: Balance,
 	) -> Self {
 		self.balances.push((who, amount));
+		self
+	}
+
+	fn add_treasury_balance(mut self, amount: Balance) -> Self {
+		let treasury_account = Treasury::treasury_account_id();
+		// println!("Treasury_account: {:?}", treasury_account);
+		// <Test as Config>::NativeBalance::set_balance(treasury_account, amount);
+		self.balances.push((treasury_account, amount));
 		self
 	}
 }

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -110,6 +110,8 @@ fn spending_proposal_instant_payout() {
 			PayoutType::Instant
 		));
 
+		System::assert_last_event(Event::AddedProposal { proposer: ALICE, index_count: 0, amount: 123_000, title: BoundedVec::truncate_from("Title".as_bytes().into()) }.into() );
+
 		// Check post state
 		assert!(SpendingProposals::<Test>::get(ALICE, 0).is_some());
 	})

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -1,13 +1,13 @@
 use crate::{mock::*, *};
-use frame_support::assert_err;
-use frame_support::traits::fungible::Inspect;
-use frame_support::traits::fungible::Mutate;
-use frame_support::traits::Hooks;
-use frame_support::{assert_ok, traits::fungibles};
+use frame_support::{
+	assert_err, assert_ok,
+	traits::{
+		fungible::{Inspect, Mutate},
+		fungibles, Hooks,
+	},
+};
 use sp_io::TestExternalities as TestState;
-use sp_runtime::traits::BadOrigin;
-use sp_runtime::BoundedVec;
-use sp_runtime::Percent;
+use sp_runtime::{traits::BadOrigin, BoundedVec, Percent};
 
 // Constants for test accounts
 pub(crate) const ALICE: u64 = 1;
@@ -394,8 +394,8 @@ pub fn payout_moved_forward() {
 			// Check periodic payment
 
 			let payment_instance_counter = i / 10;
-			let expected_balance = expected_balance_after_upfront
-				+ AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
+			let expected_balance = expected_balance_after_upfront +
+				AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
 			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
 		}
 
@@ -523,8 +523,8 @@ fn periodic_payout_complex_case() {
 
 				// Check periodic payment
 				let payment_instance_counter = i / 10;
-				let expected_balance = EXPECTED_BALANCE_AFTER_UPFRONT
-					+ AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
+				let expected_balance = EXPECTED_BALANCE_AFTER_UPFRONT +
+					AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
 				assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
 			}
 
@@ -545,9 +545,9 @@ fn periodic_payout_complex_case() {
 
 			assert_eq!(
 				<Test as Config>::NativeBalance::balance(&ALICE),
-				ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT
-					- AFTER_FULLY_COMPLETE_AMOUNT
-					- AMOUNT_PER_PERIODIC_PAYMENT
+				ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT -
+					AFTER_FULLY_COMPLETE_AMOUNT -
+					AMOUNT_PER_PERIODIC_PAYMENT
 			);
 
 			// Check Treasury balance

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -20,7 +20,7 @@ impl Default for StateBuilder {
 	fn default() -> Self {
 		let treasury_account_id = Treasury::treasury_account_id();
 
-		Self { balances: vec![(treasury_account_id, 999_999), (ALICE, 100_000), (BOB, 100_000)] }
+		Self { balances: vec![(treasury_account_id, 999_999), (ALICE, 100_000), (BOB, 500_000)] }
 	}
 }
 
@@ -54,11 +54,13 @@ impl StateBuilder {
 		self
 	}
 
-	fn add_treasury_balance(mut self, amount: Balance) -> Self {
+	fn set_treasury_balance(mut self, _amount: Balance) -> Self {
 		let treasury_account = Treasury::treasury_account_id();
-		// println!("Treasury_account: {:?}", treasury_account);
-		// <Test as Config>::NativeBalance::set_balance(treasury_account, amount);
-		self.balances.push((treasury_account, amount));
+		for (who, amount) in &mut self.balances {
+			if who == &treasury_account {
+				*amount = _amount;
+			}
+		}
 		self
 	}
 }
@@ -366,8 +368,137 @@ pub fn payout_moved_forward() {
 			.into(),
 		);
 
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 1_050_000)
-	})
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 1_050_000);
+
+		// Check Treasury balance
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
+			999_999 - 950_000
+		);
+
+		// Fund Treasury to be able to send last payment
+		let fund_treasury_amount = 1;
+		assert_ok!(Treasury::fund_treasury_native(
+			RuntimeOrigin::signed(BOB),
+			fund_treasury_amount
+		));
+
+		System::set_block_number(block_number + 20);
+		Treasury::on_initialize(block_number + 20);
+
+		// Assert that the last payment was sent
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 1_100_000);
+	});
+}
+
+#[test]
+fn periodic_payout_complex_case(){
+	StateBuilder::default().set_treasury_balance(799_999).build_and_execute(|| {
+		// Check alice balance
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 100_000);
+		// Check treasury balance
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
+			799_999
+		);
+
+		let periodic_payout = PayoutType::Periodic(PeriodicPayoutPercentage {
+			upfront: 40,
+			after_fully_complete: 20,
+			periodic: 40,
+			num_of_periodic_payouts: NumOfPeriodicPayouts::Ten,
+			payment_each_n_blocks: 10,
+		});
+
+		// Propose spend
+		assert_ok!(Treasury::propose_spend(
+			RuntimeOrigin::signed(ALICE),
+			BoundedVec::truncate_from("Title".as_bytes().into()),
+			BoundedVec::truncate_from("Description".as_bytes().to_vec()),
+			0,
+			1_000_000,
+			ALICE,
+			ALICE,
+			periodic_payout
+		));
+
+		System::assert_last_event(
+			Event::AddedProposal {
+				proposer: ALICE,
+				index_count: 0,
+				amount: 1_000_000,
+				title: BoundedVec::truncate_from("Title".as_bytes().into()),
+			}
+			.into(),
+		);
+
+		// Check if proposal is stored
+		assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
+
+		let governance_origin = GovernanceOrigin::get();
+
+		// Approve proposal
+		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
+
+		// Check upfront payment
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 500_000);
+
+		let initial_block_number = System::block_number();
+		let mut block_number = initial_block_number;
+		for i in (10..=90u128).step_by(10) {
+			// Fast forward 10 blocks
+			block_number = initial_block_number + i as u64;
+			System::set_block_number(block_number);
+			Treasury::on_initialize(block_number);
+
+			// Check periodic payment
+			let payment_instance_counter = i / 10;
+			let expected_balance = 500_000 + 40_000 * (payment_instance_counter);
+			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
+		}
+
+		System::set_block_number(block_number + 10);
+		Treasury::on_initialize(block_number + 10);
+
+		System::assert_last_event(
+			Event::PayoutMovedForward {
+				curr_block_number: 101,
+				moved_to_block_number: 111,
+				proposer: ALICE,
+				beneficiary: ALICE,
+				asset_id: 0,
+				amount: 40_000,
+			}
+			.into(),
+		);
+
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 860_000);
+
+		// Check Treasury balance
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
+			39_999
+		);
+
+		// Fund Treasury to be able to send last payment
+		let fund_treasury_amount = 500_000;
+		assert_ok!(Treasury::fund_treasury_native(
+			RuntimeOrigin::signed(BOB),
+			fund_treasury_amount
+		));
+
+		System::set_block_number(block_number + 20);
+		Treasury::on_initialize(block_number + 20);
+
+		// Assert that the last payment was sent
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 900_000);
+
+		// Confirm proposal is complete
+		assert_ok!(Treasury::confirm_full_completion(RuntimeOrigin::signed(governance_origin), ALICE, 0));
+
+		// Check Alice balance
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 1_100_000);
+	});
 }
 
 // #[test]

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -3,11 +3,10 @@ use frame_support::assert_err;
 use frame_support::traits::fungible::Inspect;
 use frame_support::traits::fungible::Mutate;
 use frame_support::traits::Hooks;
-use frame_support::{assert_noop, assert_ok, traits::fungibles};
+use frame_support::{assert_ok, traits::fungibles};
 use sp_io::TestExternalities as TestState;
 use sp_runtime::traits::BadOrigin;
 use sp_runtime::BoundedVec;
-use crate::tests::AmountHeldOnProposal;
 
 pub(crate) const ALICE: u64 = 1;
 pub(crate) const BOB: u64 = 2;
@@ -21,9 +20,7 @@ impl Default for StateBuilder {
 	fn default() -> Self {
 		let treasury_account_id = Treasury::treasury_account_id();
 
-		Self {
-			balances: vec![(treasury_account_id, 999_999), (ALICE, 100_000), (BOB, 100_000)],
-		}
+		Self { balances: vec![(treasury_account_id, 999_999), (ALICE, 100_000), (BOB, 100_000)] }
 	}
 }
 
@@ -111,7 +108,15 @@ fn spending_proposal_instant_payout() {
 			PayoutType::Instant
 		));
 
-		System::assert_last_event(Event::AddedProposal { proposer: ALICE, index_count: 0, amount: 123_000, title: BoundedVec::truncate_from("Title".as_bytes().into()) }.into() );
+		System::assert_last_event(
+			Event::AddedProposal {
+				proposer: ALICE,
+				index_count: 0,
+				amount: 123_000,
+				title: BoundedVec::truncate_from("Title".as_bytes().into()),
+			}
+			.into(),
+		);
 
 		// Check post state
 		assert!(SpendingProposals::<Test>::get(ALICE, 0).is_some());
@@ -136,7 +141,15 @@ fn approve_proposal_instant_payout() {
 			PayoutType::Instant
 		));
 
-		System::assert_last_event(Event::AddedProposal { proposer: ALICE, index_count: 0, amount: 123_000, title: BoundedVec::truncate_from("Title".as_bytes().into()) }.into() );
+		System::assert_last_event(
+			Event::AddedProposal {
+				proposer: ALICE,
+				index_count: 0,
+				amount: 123_000,
+				title: BoundedVec::truncate_from("Title".as_bytes().into()),
+			}
+			.into(),
+		);
 
 		// Check pre state
 		assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
@@ -177,7 +190,15 @@ fn approve_proposal_periodic_payout() {
 			periodic_payout
 		));
 
-		System::assert_last_event(Event::AddedProposal { proposer: ALICE, index_count: 0, amount: 100_000, title: BoundedVec::truncate_from("Title".as_bytes().into()) }.into() );
+		System::assert_last_event(
+			Event::AddedProposal {
+				proposer: ALICE,
+				index_count: 0,
+				amount: 100_000,
+				title: BoundedVec::truncate_from("Title".as_bytes().into()),
+			}
+			.into(),
+		);
 
 		// Check if proposal is stored
 		assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
@@ -193,7 +214,7 @@ fn approve_proposal_periodic_payout() {
 		let initial_block_number = System::block_number();
 		for i in (0..100u128).step_by(10) {
 			// Fast forward 10 blocks
-			let block_number: u64 =  initial_block_number + i as u64;
+			let block_number: u64 = initial_block_number + i as u64;
 			System::set_block_number(block_number);
 			Treasury::on_initialize(block_number);
 
@@ -209,7 +230,7 @@ fn approve_proposal_periodic_payout() {
 }
 
 #[test]
-fn do_propose_spend_wrong_payout_type(){
+fn do_propose_spend_wrong_payout_type() {
 	StateBuilder::default().build_and_execute(|| {
 		// Check alice balance
 		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 100_000);
@@ -223,19 +244,21 @@ fn do_propose_spend_wrong_payout_type(){
 		});
 
 		// Propose spend
-		assert_err!(Treasury::propose_spend(
-			RuntimeOrigin::signed(ALICE),
-			BoundedVec::truncate_from("Title".as_bytes().into()),
-			BoundedVec::truncate_from("Description".as_bytes().to_vec()),
-			0,
-			100_000,
-			ALICE,
-			ALICE,
-			periodic_payout
-		), Error::<Test>::PayoutPercentagesMustSumTo100);
+		assert_err!(
+			Treasury::propose_spend(
+				RuntimeOrigin::signed(ALICE),
+				BoundedVec::truncate_from("Title".as_bytes().into()),
+				BoundedVec::truncate_from("Description".as_bytes().to_vec()),
+				0,
+				100_000,
+				ALICE,
+				ALICE,
+				periodic_payout
+			),
+			Error::<Test>::PayoutPercentagesMustSumTo100
+		);
 
 		assert_eq!(System::events().len(), 0);
-
 	})
 }
 
@@ -317,6 +340,9 @@ fn handle_assets() {
 		));
 
 		// And here we can see that alice has this balance.
-		assert_eq!(<Test as Config>::Fungibles::balance(asset_id, &alice), <Test as pallet::Config>::AmountHeldOnProposal::get());
+		assert_eq!(
+			<Test as Config>::Fungibles::balance(asset_id, &alice),
+			<Test as pallet::Config>::AmountHeldOnProposal::get()
+		);
 	});
 }

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -1,15 +1,60 @@
 use crate::{mock::*, *};
 use frame_support::{assert_noop, assert_ok, traits::fungibles};
+use sp_io::TestExternalities as TestState;
+
+pub(crate) const ALICE: u64 = 1;
+pub(crate) const BOB: u64 = 2;
+pub(crate) const CHARLIE: u64 = 3;
+
+pub(crate) struct StateBuilder {
+	balances: Vec<(<Test as frame_system::Config>::AccountId, Balance)>,
+}
+
+impl Default for StateBuilder {
+	fn default() -> Self {
+		Self { balances: vec![(ALICE, 100_000), (BOB, 100_000)] }
+	}
+}
+
+impl StateBuilder {
+	pub(crate) fn build_and_execute(self, test: impl FnOnce() -> ()) {
+		let mut ext = TestState::new_empty();
+
+		// Setup initial state
+		ext.execute_with(|| {
+
+		});
+
+		ext.execute_with(test);
+
+		// Assertions that must always hold
+		ext.execute_with(|| {
+			assert_eq!(
+				true,
+				true
+			);
+		})
+	}
+
+	fn add_balance(
+		mut self,
+		who: <Test as frame_system::Config>::AccountId,
+		amount: Balance,
+	) -> Self {
+		self.balances.push((who, amount));
+		self
+	}
+}
 
 #[test]
 fn it_works_for_default_value() {
-	new_test_ext().execute_with(|| {
+	StateBuilder::default().build_and_execute(|| {
 		// Go past genesis block so events get deposited
 		System::set_block_number(1);
 		// Dispatch a signed extrinsic.
 		assert_ok!(Treasury::do_something(RuntimeOrigin::signed(1), 42));
 		// Read pallet storage and assert an expected result.
-		assert_eq!(Something::<Test>::get(), Some(42));
+		// assert_eq!(Something::<Test>::get(), Some(42));
 		// Assert that the correct event was deposited
 		System::assert_last_event(Event::SomethingStored { something: 42, who: 1 }.into());
 	});
@@ -17,15 +62,15 @@ fn it_works_for_default_value() {
 
 #[test]
 fn correct_error_for_none_value() {
-	new_test_ext().execute_with(|| {
+	StateBuilder::default().build_and_execute(|| {
 		// Ensure the expected error is thrown when no value is present.
-		assert_noop!(Treasury::cause_error(RuntimeOrigin::signed(1)), Error::<Test>::NoneValue);
+		// assert_noop!(Treasury::cause_error(RuntimeOrigin::signed(1)), Error::<Test>::NoneValue);
 	});
 }
 
 #[test]
 fn handle_assets() {
-	new_test_ext().execute_with(|| {
+	StateBuilder::default().build_and_execute(|| {
 		let alice = 1;
 		let asset_id = 1337;
 

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -7,6 +7,7 @@ use frame_support::{assert_noop, assert_ok, traits::fungibles};
 use sp_io::TestExternalities as TestState;
 use sp_runtime::traits::BadOrigin;
 use sp_runtime::BoundedVec;
+use crate::tests::AmountHeldOnProposal;
 
 pub(crate) const ALICE: u64 = 1;
 pub(crate) const BOB: u64 = 2;
@@ -146,7 +147,7 @@ fn approve_proposal_instant_payout() {
 		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
 
 		// Check Alice post balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 223_000 - 100);
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 223_000);
 	})
 }
 
@@ -187,7 +188,7 @@ fn approve_proposal_periodic_payout() {
 		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
 
 		// Check upfront payment
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 120_000 - 100);
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 120_000);
 
 		let initial_block_number = System::block_number();
 		for i in (0..100u128).step_by(10) {
@@ -198,12 +199,12 @@ fn approve_proposal_periodic_payout() {
 
 			// Check periodic payment
 			let payment_instance_counter = i / 10 + 1;
-			let expected_balance = 120_000 + 8_000 * (payment_instance_counter) - 100;
+			let expected_balance = 120_000 + 8_000 * (payment_instance_counter);
 			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
 		}
 
 		// Check Alice balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 200_000 - 100);
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 200_000);
 	})
 }
 
@@ -316,6 +317,6 @@ fn handle_assets() {
 		));
 
 		// And here we can see that alice has this balance.
-		assert_eq!(<Test as Config>::Fungibles::balance(asset_id, &alice), 100);
+		assert_eq!(<Test as Config>::Fungibles::balance(asset_id, &alice), <Test as pallet::Config>::AmountHeldOnProposal::get());
 	});
 }

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{mock::*, *};
-use frame_support::traits::fungible::Mutate;
 use frame_support::traits::fungible::Inspect;
+use frame_support::traits::fungible::Mutate;
 use frame_support::{assert_noop, assert_ok, traits::fungibles};
 use sp_io::TestExternalities as TestState;
 
@@ -19,11 +19,7 @@ impl Default for StateBuilder {
 
 		Self {
 			treasury_account_id,
-			balances: vec![
-				(treasury_account_id, 999_999),
-				(ALICE, 100_000),
-				(BOB, 100_000),
-			],
+			balances: vec![(treasury_account_id, 999_999), (ALICE, 100_000), (BOB, 100_000)],
 		}
 	}
 }
@@ -67,21 +63,29 @@ impl StateBuilder {
 
 #[test]
 fn fund_treasury_asset() {
-	StateBuilder::default()
-		.build_and_execute(|| {
-			// Check initial treasury balance
-			let treasury_account = &Treasury::treasury_account_id();
-			assert_eq!(<Test as Config>::NativeBalance::balance(treasury_account), 999_999);
+	StateBuilder::default().build_and_execute(|| {
+		// Check initial treasury balance
+		let treasury_account = &Treasury::treasury_account_id();
+		assert_eq!(<Test as Config>::NativeBalance::balance(treasury_account), 999_999);
 
-			// Fund Treasury
-			let fund_treasury_amount = 1;
-			assert_ok!(Treasury::fund_treasury_native(RuntimeOrigin::signed(ALICE), fund_treasury_amount)); 
+		// Fund Treasury
+		let fund_treasury_amount = 1;
+		assert_ok!(Treasury::fund_treasury_native(
+			RuntimeOrigin::signed(ALICE),
+			fund_treasury_amount
+		));
 
-			// Check Treasury balance after funding
-			assert_eq!(<Test as Config>::NativeBalance::balance(treasury_account), 999_999 + fund_treasury_amount);
-			// Check Alice balance after funding
-			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 100_000 - fund_treasury_amount);
-		});
+		// Check Treasury balance after funding
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(treasury_account),
+			999_999 + fund_treasury_amount
+		);
+		// Check Alice balance after funding
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			100_000 - fund_treasury_amount
+		);
+	});
 }
 
 #[test]

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -3,6 +3,7 @@ use frame_support::traits::fungible::Inspect;
 use frame_support::traits::fungible::Mutate;
 use frame_support::{assert_noop, assert_ok, traits::fungibles};
 use sp_io::TestExternalities as TestState;
+use sp_runtime::BoundedVec;
 
 pub(crate) const ALICE: u64 = 1;
 pub(crate) const BOB: u64 = 2;
@@ -86,6 +87,23 @@ fn fund_treasury_asset() {
 			100_000 - fund_treasury_amount
 		);
 	});
+}
+
+#[test]
+fn propose_spend() {
+	StateBuilder::default().build_and_execute(|| {
+		// Propose spend
+		assert_ok!(Treasury::propose_spend(
+			RuntimeOrigin::signed(ALICE),
+			BoundedVec::truncate_from("Title".as_bytes().into()),
+			BoundedVec::truncate_from("Description".as_bytes().to_vec()),
+			0,
+			123_000,
+			ALICE,
+			ALICE,
+			PayoutType::Instant
+		));
+	})
 }
 
 #[test]

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -14,7 +14,6 @@ pub(crate) const CHARLIE: u64 = 3;
 
 pub(crate) struct StateBuilder {
 	balances: Vec<(<Test as frame_system::Config>::AccountId, Balance)>,
-	treasury_account_id: <Test as frame_system::Config>::AccountId,
 }
 
 impl Default for StateBuilder {
@@ -22,7 +21,6 @@ impl Default for StateBuilder {
 		let treasury_account_id = Treasury::treasury_account_id();
 
 		Self {
-			treasury_account_id,
 			balances: vec![(treasury_account_id, 999_999), (ALICE, 100_000), (BOB, 100_000)],
 		}
 	}
@@ -188,7 +186,7 @@ fn approve_proposal_periodic_payout() {
 		let initial_block_number = System::block_number();
 		for i in (0..100u128).step_by(10) {
 			// Fast forward 10 blocks
-			let block_number: u64 = initial_block_number + i as u64;
+			let block_number: u64 =  initial_block_number + i as u64;
 			System::set_block_number(block_number);
 			Treasury::on_initialize(block_number);
 
@@ -204,7 +202,7 @@ fn approve_proposal_periodic_payout() {
 }
 
 #[test]
-fn do_propose_spend_wrong_payout_type() {
+fn do_propose_spend_wrong_payout_type(){
 	StateBuilder::default().build_and_execute(|| {
 		// Check alice balance
 		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 100_000);
@@ -218,19 +216,16 @@ fn do_propose_spend_wrong_payout_type() {
 		});
 
 		// Propose spend
-		assert_err!(
-			Treasury::propose_spend(
-				RuntimeOrigin::signed(ALICE),
-				BoundedVec::truncate_from("Title".as_bytes().into()),
-				BoundedVec::truncate_from("Description".as_bytes().to_vec()),
-				0,
-				100_000,
-				ALICE,
-				ALICE,
-				periodic_payout
-			),
-			Error::<Test>::PayoutPercentagesMustSumTo100
-		);
+		assert_err!(Treasury::propose_spend(
+			RuntimeOrigin::signed(ALICE),
+			BoundedVec::truncate_from("Title".as_bytes().into()),
+			BoundedVec::truncate_from("Description".as_bytes().to_vec()),
+			0,
+			100_000,
+			ALICE,
+			ALICE,
+			periodic_payout
+		), Error::<Test>::PayoutPercentagesMustSumTo100);
 	})
 }
 
@@ -257,19 +252,19 @@ fn approve_proposal_bad_origin() {
 	})
 }
 
-#[test]
-fn it_works_for_default_value() {
-	StateBuilder::default().build_and_execute(|| {
-		// Go past genesis block so events get deposited
-		System::set_block_number(1);
-		// Dispatch a signed extrinsic.
-		assert_ok!(Treasury::do_something(RuntimeOrigin::signed(1), 42));
-		// Read pallet storage and assert an expected result.
-		// assert_eq!(Something::<Test>::get(), Some(42));
-		// Assert that the correct event was deposited
-		System::assert_last_event(Event::SomethingStored { something: 42, who: 1 }.into());
-	});
-}
+// #[test]
+// fn it_works_for_default_value() {
+// 	StateBuilder::default().build_and_execute(|| {
+// 		// Go past genesis block so events get deposited
+// 		System::set_block_number(1);
+// 		// Dispatch a signed extrinsic.
+// 		assert_ok!(Treasury::do_something(RuntimeOrigin::signed(1), 42));
+// 		// Read pallet storage and assert an expected result.
+// 		// assert_eq!(Something::<Test>::get(), Some(42));
+// 		// Assert that the correct event was deposited
+// 		System::assert_last_event(Event::SomethingStored { something: 42, who: 1 }.into());
+// 	});
+// }
 
 #[test]
 fn correct_error_for_none_value() {

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -84,7 +84,10 @@ fn fund_treasury_asset() {
 	StateBuilder::default().build_and_execute(|| {
 		// Check initial treasury balance
 		let treasury_account = &Treasury::treasury_account_id();
-		assert_eq!(<Test as Config>::NativeBalance::balance(treasury_account), TREASURY_INITIAL_BALANCE);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(treasury_account),
+			TREASURY_INITIAL_BALANCE
+		);
 
 		// Fund Treasury
 		assert_ok!(Treasury::fund_treasury_native(
@@ -179,7 +182,10 @@ fn approve_proposal_instant_payout() {
 		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
 
 		// Check Alice post balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT
+		);
 	})
 }
 
@@ -231,7 +237,10 @@ fn approve_proposal_periodic_payout() {
 
 		// Check upfront payment
 		let expected_balance_after_upfront = ALICE_INITIAL_BALANCE + 20_000;
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance_after_upfront);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			expected_balance_after_upfront
+		);
 
 		let initial_block_number = System::block_number();
 		for i in (10..=100u128).step_by(10) {
@@ -242,12 +251,16 @@ fn approve_proposal_periodic_payout() {
 
 			// Check periodic payment
 			let payment_instance_counter = i / 10;
-			let expected_balance = expected_balance_after_upfront + 8_000 * (payment_instance_counter);
+			let expected_balance =
+				expected_balance_after_upfront + 8_000 * (payment_instance_counter);
 			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
 		}
 
 		// Check Alice balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT
+		);
 	})
 }
 
@@ -315,7 +328,7 @@ fn approve_proposal_bad_origin() {
 pub fn payout_moved_forward() {
 	StateBuilder::default().build_and_execute(|| {
 		const PROPOSAL_AMOUNT: u128 = 1_000_000;
-		
+
 		// Check alice balance
 		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE);
 		// Check treasury balance
@@ -364,7 +377,10 @@ pub fn payout_moved_forward() {
 
 		// Check upfront payment
 		let expected_balance_after_upfront = ALICE_INITIAL_BALANCE + 500_000;
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance_after_upfront);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			expected_balance_after_upfront
+		);
 
 		let initial_block_number = System::block_number();
 		let mut block_number = initial_block_number;
@@ -378,7 +394,8 @@ pub fn payout_moved_forward() {
 			// Check periodic payment
 
 			let payment_instance_counter = i / 10;
-			let expected_balance = expected_balance_after_upfront + AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
+			let expected_balance = expected_balance_after_upfront
+				+ AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
 			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
 		}
 
@@ -397,7 +414,10 @@ pub fn payout_moved_forward() {
 			.into(),
 		);
 
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT - AMOUNT_PER_PERIODIC_PAYMENT);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT - AMOUNT_PER_PERIODIC_PAYMENT
+		);
 
 		// Check Treasury balance
 		assert_eq!(
@@ -415,7 +435,10 @@ pub fn payout_moved_forward() {
 		Treasury::on_initialize(block_number + 20);
 
 		// Assert that the last payment was sent
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), PROPOSAL_AMOUNT + ALICE_INITIAL_BALANCE);
+		assert_eq!(
+			<Test as Config>::NativeBalance::balance(&ALICE),
+			PROPOSAL_AMOUNT + ALICE_INITIAL_BALANCE
+		);
 	});
 }
 
@@ -423,123 +446,142 @@ pub fn payout_moved_forward() {
 fn periodic_payout_complex_case() {
 	const TREASURY_INITIAL_BALANCE: Balance = 799_999;
 
-	StateBuilder::default().set_treasury_balance(TREASURY_INITIAL_BALANCE).build_and_execute(|| {
-		const PROPOSAL_AMOUNT: u128 = 1_000_000;
+	StateBuilder::default()
+		.set_treasury_balance(TREASURY_INITIAL_BALANCE)
+		.build_and_execute(|| {
+			const PROPOSAL_AMOUNT: u128 = 1_000_000;
 
-		// Check alice balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE);
-		// Check treasury balance
-		assert_eq!(
-			<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
-			TREASURY_INITIAL_BALANCE
-		);
+			// Check alice balance
+			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE);
+			// Check treasury balance
+			assert_eq!(
+				<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
+				TREASURY_INITIAL_BALANCE
+			);
 
-		let periodic_payout = PayoutType::Periodic(PeriodicPayoutPercentage {
-			upfront: 40,
-			after_fully_complete: 20,
-			periodic: 40,
-			num_of_periodic_payouts: NumOfPeriodicPayouts::Ten,
-			payment_each_n_blocks: 10,
+			let periodic_payout = PayoutType::Periodic(PeriodicPayoutPercentage {
+				upfront: 40,
+				after_fully_complete: 20,
+				periodic: 40,
+				num_of_periodic_payouts: NumOfPeriodicPayouts::Ten,
+				payment_each_n_blocks: 10,
+			});
+
+			let AFTER_FULLY_COMPLETE_AMOUNT: u128 = Percent::from_percent(20) * PROPOSAL_AMOUNT;
+
+			// Propose spend
+			assert_ok!(Treasury::propose_spend(
+				RuntimeOrigin::signed(ALICE),
+				BoundedVec::truncate_from("Title".as_bytes().into()),
+				BoundedVec::truncate_from("Description".as_bytes().to_vec()),
+				0,
+				PROPOSAL_AMOUNT,
+				ALICE,
+				ALICE,
+				periodic_payout
+			));
+
+			System::assert_last_event(
+				Event::AddedProposal {
+					proposer: ALICE,
+					index_count: 0,
+					amount: PROPOSAL_AMOUNT,
+					title: BoundedVec::truncate_from("Title".as_bytes().into()),
+				}
+				.into(),
+			);
+
+			// Check if proposal is stored
+			assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
+
+			let governance_origin = GovernanceOrigin::get();
+
+			// Approve proposal
+			assert_ok!(Treasury::approve_proposal(
+				RuntimeOrigin::signed(governance_origin),
+				ALICE,
+				0
+			));
+
+			// Check upfront payment
+			const EXPECTED_UPFRONT_PAYMENT: u128 = 400_000;
+			assert_eq!(
+				<Test as Config>::NativeBalance::balance(&ALICE),
+				ALICE_INITIAL_BALANCE + EXPECTED_UPFRONT_PAYMENT
+			);
+
+			let initial_block_number = System::block_number();
+			let mut block_number = initial_block_number;
+			const EXPECTED_BALANCE_AFTER_UPFRONT: u128 =
+				ALICE_INITIAL_BALANCE + EXPECTED_UPFRONT_PAYMENT;
+			const AMOUNT_PER_PERIODIC_PAYMENT: u128 = 40_000;
+			for i in (10..=90u128).step_by(10) {
+				// Fast forward 10 blocks
+				block_number = initial_block_number + i as u64;
+				System::set_block_number(block_number);
+				Treasury::on_initialize(block_number);
+
+				// Check periodic payment
+				let payment_instance_counter = i / 10;
+				let expected_balance = EXPECTED_BALANCE_AFTER_UPFRONT
+					+ AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
+				assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
+			}
+
+			System::set_block_number(block_number + 10);
+			Treasury::on_initialize(block_number + 10);
+
+			System::assert_last_event(
+				Event::PayoutMovedForward {
+					curr_block_number: 101,
+					moved_to_block_number: 111,
+					proposer: ALICE,
+					beneficiary: ALICE,
+					asset_id: 0,
+					amount: AMOUNT_PER_PERIODIC_PAYMENT,
+				}
+				.into(),
+			);
+
+			assert_eq!(
+				<Test as Config>::NativeBalance::balance(&ALICE),
+				ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT
+					- AFTER_FULLY_COMPLETE_AMOUNT
+					- AMOUNT_PER_PERIODIC_PAYMENT
+			);
+
+			// Check Treasury balance
+			assert_eq!(
+				<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
+				39_999
+			);
+
+			// Fund Treasury to be able to send last payment
+			let fund_treasury_amount = 500_000;
+			assert_ok!(Treasury::fund_treasury_native(
+				RuntimeOrigin::signed(BOB),
+				fund_treasury_amount
+			));
+
+			System::set_block_number(block_number + 20);
+			Treasury::on_initialize(block_number + 20);
+
+			// Assert that the last payment was sent
+			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 900_000);
+
+			// Confirm proposal is complete
+			assert_ok!(Treasury::confirm_full_completion(
+				RuntimeOrigin::signed(governance_origin),
+				ALICE,
+				0
+			));
+
+			// Check Alice balance
+			assert_eq!(
+				<Test as Config>::NativeBalance::balance(&ALICE),
+				PROPOSAL_AMOUNT + ALICE_INITIAL_BALANCE
+			);
 		});
-
-		let AFTER_FULLY_COMPLETE_AMOUNT: u128 = Percent::from_percent(20) * PROPOSAL_AMOUNT; 
-
-		// Propose spend
-		assert_ok!(Treasury::propose_spend(
-			RuntimeOrigin::signed(ALICE),
-			BoundedVec::truncate_from("Title".as_bytes().into()),
-			BoundedVec::truncate_from("Description".as_bytes().to_vec()),
-			0,
-			PROPOSAL_AMOUNT,
-			ALICE,
-			ALICE,
-			periodic_payout
-		));
-
-		System::assert_last_event(
-			Event::AddedProposal {
-				proposer: ALICE,
-				index_count: 0,
-				amount: PROPOSAL_AMOUNT,
-				title: BoundedVec::truncate_from("Title".as_bytes().into()),
-			}
-			.into(),
-		);
-
-		// Check if proposal is stored
-		assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
-
-		let governance_origin = GovernanceOrigin::get();
-
-		// Approve proposal
-		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
-
-		// Check upfront payment
-		const EXPECTED_UPFRONT_PAYMENT: u128 = 400_000;
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE + EXPECTED_UPFRONT_PAYMENT);
-
-		let initial_block_number = System::block_number();
-		let mut block_number = initial_block_number;
-		const EXPECTED_BALANCE_AFTER_UPFRONT: u128 = ALICE_INITIAL_BALANCE + EXPECTED_UPFRONT_PAYMENT;
-		const AMOUNT_PER_PERIODIC_PAYMENT: u128 = 40_000;
-		for i in (10..=90u128).step_by(10) {
-			// Fast forward 10 blocks
-			block_number = initial_block_number + i as u64;
-			System::set_block_number(block_number);
-			Treasury::on_initialize(block_number);
-
-			// Check periodic payment
-			let payment_instance_counter = i / 10;
-			let expected_balance = EXPECTED_BALANCE_AFTER_UPFRONT + AMOUNT_PER_PERIODIC_PAYMENT * (payment_instance_counter);
-			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
-		}
-
-		System::set_block_number(block_number + 10);
-		Treasury::on_initialize(block_number + 10);
-
-		System::assert_last_event(
-			Event::PayoutMovedForward {
-				curr_block_number: 101,
-				moved_to_block_number: 111,
-				proposer: ALICE,
-				beneficiary: ALICE,
-				asset_id: 0,
-				amount: AMOUNT_PER_PERIODIC_PAYMENT,
-			}
-			.into(),
-		);
-
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), ALICE_INITIAL_BALANCE + PROPOSAL_AMOUNT - AFTER_FULLY_COMPLETE_AMOUNT - AMOUNT_PER_PERIODIC_PAYMENT);
-
-		// Check Treasury balance
-		assert_eq!(
-			<Test as Config>::NativeBalance::balance(&Treasury::treasury_account_id()),
-			39_999
-		);
-
-		// Fund Treasury to be able to send last payment
-		let fund_treasury_amount = 500_000;
-		assert_ok!(Treasury::fund_treasury_native(
-			RuntimeOrigin::signed(BOB),
-			fund_treasury_amount
-		));
-
-		System::set_block_number(block_number + 20);
-		Treasury::on_initialize(block_number + 20);
-
-		// Assert that the last payment was sent
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 900_000);
-
-		// Confirm proposal is complete
-		assert_ok!(Treasury::confirm_full_completion(
-			RuntimeOrigin::signed(governance_origin),
-			ALICE,
-			0
-		));
-
-		// Check Alice balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), PROPOSAL_AMOUNT + ALICE_INITIAL_BALANCE);
-	});
 }
 
 #[test]

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -266,13 +266,13 @@ fn approve_proposal_bad_origin() {
 // 	});
 // }
 
-#[test]
-fn correct_error_for_none_value() {
-	StateBuilder::default().build_and_execute(|| {
-		// Ensure the expected error is thrown when no value is present.
-		// assert_noop!(Treasury::cause_error(RuntimeOrigin::signed(1)), Error::<Test>::NoneValue);
-	});
-}
+// #[test]
+// fn correct_error_for_none_value() {
+// 	StateBuilder::default().build_and_execute(|| {
+// 		// Ensure the expected error is thrown when no value is present.
+// 		// assert_noop!(Treasury::cause_error(RuntimeOrigin::signed(1)), Error::<Test>::NoneValue);
+// 	});
+// }
 
 #[test]
 fn handle_assets() {

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{mock::*, *};
 use frame_support::traits::fungible::Mutate;
+use frame_support::traits::fungible::Inspect;
 use frame_support::{assert_noop, assert_ok, traits::fungibles};
 use sp_io::TestExternalities as TestState;
 
@@ -9,13 +10,17 @@ pub(crate) const CHARLIE: u64 = 3;
 
 pub(crate) struct StateBuilder {
 	balances: Vec<(<Test as frame_system::Config>::AccountId, Balance)>,
+	treasury_account_id: <Test as frame_system::Config>::AccountId,
 }
 
 impl Default for StateBuilder {
 	fn default() -> Self {
+		let treasury_account_id = Treasury::treasury_account_id();
+
 		Self {
+			treasury_account_id,
 			balances: vec![
-				(Treasury::treasury_account_id(), 999_999),
+				(treasury_account_id, 999_999),
 				(ALICE, 100_000),
 				(BOB, 100_000),
 			],
@@ -36,7 +41,7 @@ impl StateBuilder {
 
 		ext.execute_with(test);
 
-		// Assertions that must always hold
+		// Assertions that must always hold (system invariants)
 		ext.execute_with(|| {
 			assert_eq!(true, true);
 		})
@@ -58,6 +63,25 @@ impl StateBuilder {
 		self.balances.push((treasury_account, amount));
 		self
 	}
+}
+
+#[test]
+fn fund_treasury_asset() {
+	StateBuilder::default()
+		.build_and_execute(|| {
+			// Check initial treasury balance
+			let treasury_account = &Treasury::treasury_account_id();
+			assert_eq!(<Test as Config>::NativeBalance::balance(treasury_account), 999_999);
+
+			// Fund Treasury
+			let fund_treasury_amount = 1;
+			assert_ok!(Treasury::fund_treasury_native(RuntimeOrigin::signed(ALICE), fund_treasury_amount)); 
+
+			// Check Treasury balance after funding
+			assert_eq!(<Test as Config>::NativeBalance::balance(treasury_account), 999_999 + fund_treasury_amount);
+			// Check Alice balance after funding
+			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 100_000 - fund_treasury_amount);
+		});
 }
 
 #[test]

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -349,7 +349,6 @@ pub fn payout_moved_forward() {
 			let payment_instance_counter = i / 10;
 			let expected_balance = 600_000 + 50_000 * (payment_instance_counter);
 			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
-			println!("BLOCK: {}", block_number);
 		}
 
 		System::set_block_number(block_number + 10);

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -135,6 +135,8 @@ fn approve_proposal_instant_payout() {
 			PayoutType::Instant
 		));
 
+		System::assert_last_event(Event::AddedProposal { proposer: ALICE, index_count: 0, amount: 123_000, title: BoundedVec::truncate_from("Title".as_bytes().into()) }.into() );
+
 		// Check pre state
 		assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
 
@@ -144,7 +146,7 @@ fn approve_proposal_instant_payout() {
 		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
 
 		// Check Alice post balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 223_000);
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 223_000 - 100);
 	})
 }
 
@@ -174,6 +176,8 @@ fn approve_proposal_periodic_payout() {
 			periodic_payout
 		));
 
+		System::assert_last_event(Event::AddedProposal { proposer: ALICE, index_count: 0, amount: 100_000, title: BoundedVec::truncate_from("Title".as_bytes().into()) }.into() );
+
 		// Check if proposal is stored
 		assert_eq!(SpendingProposals::<Test>::get(ALICE, 0).unwrap().approved, false);
 
@@ -183,7 +187,7 @@ fn approve_proposal_periodic_payout() {
 		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::signed(governance_origin), ALICE, 0));
 
 		// Check upfront payment
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 120_000);
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 120_000 - 100);
 
 		let initial_block_number = System::block_number();
 		for i in (0..100u128).step_by(10) {
@@ -194,12 +198,12 @@ fn approve_proposal_periodic_payout() {
 
 			// Check periodic payment
 			let payment_instance_counter = i / 10 + 1;
-			let expected_balance = 120_000 + 8_000 * (payment_instance_counter);
+			let expected_balance = 120_000 + 8_000 * (payment_instance_counter) - 100;
 			assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), expected_balance);
 		}
 
 		// Check Alice balance
-		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 200_000);
+		assert_eq!(<Test as Config>::NativeBalance::balance(&ALICE), 200_000 - 100);
 	})
 }
 
@@ -228,6 +232,9 @@ fn do_propose_spend_wrong_payout_type(){
 			ALICE,
 			periodic_payout
 		), Error::<Test>::PayoutPercentagesMustSumTo100);
+
+		assert_eq!(System::events().len(), 0);
+
 	})
 }
 


### PR DESCRIPTION
TODO:

Hold assets on proposal to disable spamming chain. :heavy_check_mark: 
Handle cases where there is not enough of some token for a spend. :heavy_check_mark: 
Tests. :dagger: :heavy_check_mark: 
_Offchain worker for more complex (periodic) fund release strategy to avoid hooks? :thinking:_ 
Add custom events and errors. :heavy_check_mark: 

Support APIs to balance the amount of funds in the treasury: :heavy_check_mark: 
  - For example, given some token price API, converting DOT to USD within some limit to ensure that
    enough of each token is present in the treasury. :heavy_check_mark: 
